### PR TITLE
[DOM-307] Add push feature enabled endpoints

### DIFF
--- a/Doppler.UserSitesIntegration/Controllers/SiteController.cs
+++ b/Doppler.UserSitesIntegration/Controllers/SiteController.cs
@@ -15,5 +15,12 @@ namespace Doppler.UserSitesIntegration.Controllers
             throw new NotImplementedException();
         }
 
+        [AllowAnonymous]
+        [HttpGet]
+        [Route("sites/{domain}/isPushFeatureEnabled")]
+        public Task<ActionResult<bool>> IsPushFeatureEnabled([FromRoute] string domain)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Doppler.UserSitesIntegration/Controllers/SiteController.cs
+++ b/Doppler.UserSitesIntegration/Controllers/SiteController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+
+namespace Doppler.UserSitesIntegration.Controllers
+{
+    [ApiController]
+    public class SiteController : ControllerBase
+    {
+        [HttpPut]
+        [Route("accounts/{accountName}/sites/{domain}/isPushFeatureEnabled")]
+        public Task<ActionResult> SetPushFeatureEnabled([FromRoute] string accountName, [FromRoute] string domain, [FromBody] bool isPushFeatureEnabled)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ UserSitesIntegrationApi->>+Storage: update site
 UserSitesIntegrationApi-->>-UserSitesIntegrationMfe: success
 UserSitesIntegrationMfe-->>-DopplerUser: done!
 ```
+
+# Get push feature status by domain name
+
+```mermaid
+sequenceDiagram
+  participant ApiConsumer
+  participant UserSitesIntegrationApi
+  participant Storage
+ApiConsumer->>+UserSitesIntegrationApi: GET /sites/{domain}/isPushFeatureEnabled
+UserSitesIntegrationApi->>+Storage: get push feature status by site
+UserSitesIntegrationApi-->>-ApiConsumer: push feature status
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # doppler-user-sites-integration
+
+# Enable/disable push feature in specific domain
+
+```mermaid
+sequenceDiagram
+  participant DopplerUser
+  participant UserSitesIntegrationMfe
+  participant UserSitesIntegrationApi
+  participant Storage
+DopplerUser->>+UserSitesIntegrationMfe: enable/disable push feature in specific site
+UserSitesIntegrationMfe->>+UserSitesIntegrationApi: PUT /accounts/{accountName}/sites/{domain}/isPushFeatureEnabled
+UserSitesIntegrationApi->>+Storage: update site
+UserSitesIntegrationApi-->>-UserSitesIntegrationMfe: success
+UserSitesIntegrationMfe-->>-DopplerUser: done!
+```


### PR DESCRIPTION
Right now, this behavior is in [doppler-push-contact](https://github.com/FromDoppler/doppler-push-contact) API. 
Please, take a look: 

- https://github.com/FromDoppler/doppler-push-contact#enabledisable-push-feature-in-specific-domain-from-doppler 
- https://github.com/FromDoppler/doppler-push-contact#get-push-feature-status-by-domain-name

Now, we have an API (this one) with this scope.

Related to https://makingsense.atlassian.net/browse/DOM-307