### PR TITLE
[DOM-303] Doppler database access implementation

### DIFF
--- a/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DapperProviderServiceCollectionExtensions.cs
+++ b/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DapperProviderServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Doppler.UserSitesIntegration.DataAccess.DapperProvider;
+
+public static class DapperProviderServiceCollectionExtensions
+{
+    public static IServiceCollection AddDapperDataAccessProvider(this IServiceCollection services, IConfiguration configuration)
+        => services
+            .AddSingleton<IDatabaseConnectionFactory, DopplerDatabaseConnectionFactory>()
+            .AddScoped<IDbContext, DapperWrapperDbContext>()
+            .Configure<DopplerDatabaseSettings>(configuration.GetSection(nameof(DopplerDatabaseSettings)));
+}

--- a/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DapperWrapperDbContext.cs
+++ b/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DapperWrapperDbContext.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using Dapper;
+
+namespace Doppler.UserSitesIntegration.DataAccess.DapperProvider;
+
+public class DapperWrapperDbContext : IDbContext, IDisposable
+{
+    private readonly Lazy<IDbConnection> _lazyDbConnection;
+    private bool _disposedValue;
+
+    public DapperWrapperDbContext(IDatabaseConnectionFactory databaseConnectionFactory)
+    {
+        _lazyDbConnection = new Lazy<IDbConnection>(() => databaseConnectionFactory.GetConnection());
+    }
+
+    public Task<TResult> ExecuteAsync<TResult>(ISingleItemDbQuery<TResult> query)
+        => _lazyDbConnection.Value.QuerySingleOrDefaultAsync<TResult>(
+            query.GenerateSqlQuery(),
+            query.GenerateSqlParameters());
+
+    public Task<IEnumerable<TResult>> ExecuteAsync<TResult>(ICollectionDbQuery<TResult> query)
+        => _lazyDbConnection.Value.QueryAsync<TResult>(
+            query.GenerateSqlQuery(),
+            query.GenerateSqlParameters());
+
+    public Task<int> ExecuteAsync(IExecutableDbQuery query)
+        => _lazyDbConnection.Value.ExecuteAsync(
+            query.GenerateSqlQuery(),
+            query.GenerateSqlParameters());
+
+    public void Dispose()
+    {
+        if (!_disposedValue && _lazyDbConnection.IsValueCreated)
+        {
+            _disposedValue = true;
+            _lazyDbConnection.Value.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DopplerDatabaseConnectionFactory.cs
+++ b/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DopplerDatabaseConnectionFactory.cs
@@ -1,0 +1,18 @@
+using System.Data;
+using System.Data.SqlClient;
+using Microsoft.Extensions.Options;
+
+namespace Doppler.UserSitesIntegration.DataAccess.DapperProvider;
+
+public class DopplerDatabaseConnectionFactory : IDatabaseConnectionFactory
+{
+    private readonly string _connectionString;
+
+    public DopplerDatabaseConnectionFactory(IOptions<DopplerDatabaseSettings> dopplerDatabaseSettings)
+    {
+        _connectionString = dopplerDatabaseSettings.Value.GetSqlConnectionString();
+    }
+
+    public IDbConnection GetConnection()
+        => new SqlConnection(_connectionString);
+}

--- a/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DopplerDatabaseSettings.cs
+++ b/Doppler.UserSitesIntegration/DataAccess.DapperProvider/DopplerDatabaseSettings.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Data.SqlClient;
+
+namespace Doppler.UserSitesIntegration.DataAccess.DapperProvider;
+
+public class DopplerDatabaseSettings
+{
+    public string ConnectionString { get; set; }
+
+    public string Password { get; set; }
+
+    public int CommandTimeOut { get; set; } = 1200;
+
+    public int MaxRetryAttempts { get; set; } = 10;
+
+    public string GetSqlConnectionString()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+        {
+            throw new ArgumentException("The string argument 'connectionString' cannot be empty.");
+        }
+
+        var builder = new SqlConnectionStringBuilder(ConnectionString);
+
+        if (!string.IsNullOrWhiteSpace(Password))
+        {
+            builder.Password = Password;
+        }
+
+        return builder.ConnectionString;
+    }
+}

--- a/Doppler.UserSitesIntegration/DataAccess.DapperProvider/IDatabaseConnectionFactory.cs
+++ b/Doppler.UserSitesIntegration/DataAccess.DapperProvider/IDatabaseConnectionFactory.cs
@@ -1,0 +1,8 @@
+using System.Data;
+
+namespace Doppler.UserSitesIntegration.DataAccess.DapperProvider;
+
+public interface IDatabaseConnectionFactory
+{
+    IDbConnection GetConnection();
+}

--- a/Doppler.UserSitesIntegration/DataAccess/IDbContext.cs
+++ b/Doppler.UserSitesIntegration/DataAccess/IDbContext.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Doppler.UserSitesIntegration.DataAccess;
+
+public interface IDbContext
+{
+    Task<TResult> ExecuteAsync<TResult>(ISingleItemDbQuery<TResult> query);
+
+    Task<IEnumerable<TResult>> ExecuteAsync<TResult>(ICollectionDbQuery<TResult> query);
+
+    Task<int> ExecuteAsync(IExecutableDbQuery query);
+}

--- a/Doppler.UserSitesIntegration/DataAccess/IDbQuery.cs
+++ b/Doppler.UserSitesIntegration/DataAccess/IDbQuery.cs
@@ -1,0 +1,13 @@
+namespace Doppler.UserSitesIntegration.DataAccess;
+
+public interface IDbQuery
+{
+    string GenerateSqlQuery();
+    object GenerateSqlParameters() => this;
+}
+
+public interface IExecutableDbQuery : IDbQuery { }
+
+public interface ICollectionDbQuery<TResult> : IDbQuery { }
+
+public interface ISingleItemDbQuery<TResult> : IDbQuery { }

--- a/Doppler.UserSitesIntegration/Doppler.UserSitesIntegration.csproj
+++ b/Doppler.UserSitesIntegration/Doppler.UserSitesIntegration.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
@@ -17,6 +18,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 
 </Project>

--- a/Doppler.UserSitesIntegration/Repositories.DopplerDb/DapperFooRepository.cs
+++ b/Doppler.UserSitesIntegration/Repositories.DopplerDb/DapperFooRepository.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using Doppler.UserSitesIntegration.DataAccess;
+using Doppler.UserSitesIntegration.Repositories.DopplerDb.Queries;
+
+namespace Doppler.UserSitesIntegration.Repositories.DopplerDb;
+
+public class DapperFooRepository : IFooRepository
+{
+    private readonly IDbContext _dbContext;
+
+    public DapperFooRepository(IDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task CreateFooAsync()
+    {
+        var insertFooDbQuery = new InsertFooDbQuery(
+                IdFoo: 1
+            );
+
+        await _dbContext.ExecuteAsync(insertFooDbQuery);
+    }
+}

--- a/Doppler.UserSitesIntegration/Repositories.DopplerDb/DopplerDbServiceCollectionExtensions.cs
+++ b/Doppler.UserSitesIntegration/Repositories.DopplerDb/DopplerDbServiceCollectionExtensions.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Doppler.UserSitesIntegration.Repositories.DopplerDb;
+
+public static class DopplerDbServiceCollectionExtensions
+{
+    public static IServiceCollection AddDopplerDbRepositories(this IServiceCollection services)
+        => services
+            .AddScoped<IFooRepository, DapperFooRepository>();
+}

--- a/Doppler.UserSitesIntegration/Repositories.DopplerDb/Queries/InsertFooDbQuery.cs
+++ b/Doppler.UserSitesIntegration/Repositories.DopplerDb/Queries/InsertFooDbQuery.cs
@@ -1,0 +1,15 @@
+using Doppler.UserSitesIntegration.DataAccess;
+
+namespace Doppler.UserSitesIntegration.Repositories.DopplerDb.Queries;
+
+public record InsertFooDbQuery(
+    int IdFoo
+) : IExecutableDbQuery
+{
+    public string GenerateSqlQuery() => @"
+INSERT INTO Foo (
+    IdFoo
+) VALUES (
+    @IdFoo
+)";
+}

--- a/Doppler.UserSitesIntegration/Repositories/IFooRepository.cs
+++ b/Doppler.UserSitesIntegration/Repositories/IFooRepository.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Doppler.UserSitesIntegration.Repositories;
+
+public interface IFooRepository
+{
+    Task CreateFooAsync();
+}

--- a/Doppler.UserSitesIntegration/Startup.cs
+++ b/Doppler.UserSitesIntegration/Startup.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Hellang.Middleware.ProblemDetails;
+using Doppler.UserSitesIntegration.DataAccess.DapperProvider;
+using Doppler.UserSitesIntegration.Repositories.DopplerDb;
 
 namespace Doppler.UserSitesIntegration
 {
@@ -60,6 +62,9 @@ namespace Doppler.UserSitesIntegration
                     c.AddServer(new OpenApiServer() { Url = baseUrl });
                 };
             });
+
+            services.AddDapperDataAccessProvider(Configuration);
+            services.AddDopplerDbRepositories();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.UserSitesIntegration/appsettings.Development.json
+++ b/Doppler.UserSitesIntegration/appsettings.Development.json
@@ -10,5 +10,9 @@
   },
   "DopplerSecurity": {
     "PublicKeysFolder": "public-keys-dev"
+  },
+  "DopplerDataBaseSettings": {
+    "ConnectionString": "Server=REPLACE_FOR_SQL_SERVER;Database=REPLACE_FOR_DATABASE_NAME;User Id=REPLACE_FOR_DATABASE_USERNAME; MultipleActiveResultSets=True;",
+    "Password": "REPLACE_FOR_DATABASE_PASSWORD"
   }
 }

--- a/Doppler.UserSitesIntegration/appsettings.json
+++ b/Doppler.UserSitesIntegration/appsettings.json
@@ -15,5 +15,9 @@
   "DopplerSecurity": {
     "PublicKeysFolder": "public-keys",
     "PublicKeysFilenameRegex": "\\.xml$"
+  },
+  "DopplerDataBaseSettings": {
+    "ConnectionString": "Server=REPLACE_FOR_SQL_SERVER;Database=REPLACE_FOR_DATABASE_NAME;User Id=REPLACE_FOR_DATABASE_USERNAME; MultipleActiveResultSets=True;",
+    "Password": "REPLACE_FOR_DATABASE_PASSWORD"
   }
 }


### PR DESCRIPTION
We will access the Doppler database to manage settings related to _User Site Tracking_ and _Push Notification_.

This PR includes the _Dapper_ data access provider (based on [doppler-html-editor-api](https://github.com/FromDoppler/doppler-html-editor-api) implementation) and a _foo_ repository as a sample.

Related to [DOM-303](https://makingsense.atlassian.net/browse/DOM-303)